### PR TITLE
Add failing test for Delete with a where clause evaluating to false

### DIFF
--- a/src/test/Z.Test.EntityFramework.Plus.EF6/BatchDelete/WhereValue/False.cs
+++ b/src/test/Z.Test.EntityFramework.Plus.EF6/BatchDelete/WhereValue/False.cs
@@ -1,0 +1,36 @@
+﻿// Description: Entity Framework Bulk Operations & Utilities (EF Bulk SaveChanges, Insert, Update, Delete, Merge | LINQ Query Cache, Deferred, Filter, IncludeFilter, IncludeOptimize | Audit)
+// Website & Documentation: https://github.com/zzzprojects/Entity-Framework-Plus
+// Forum & Issues: https://github.com/zzzprojects/EntityFramework-Plus/issues
+// License: https://github.com/zzzprojects/EntityFramework-Plus/blob/master/LICENSE
+// More projects: http://www.zzzprojects.com/
+// Copyright © ZZZ Projects Inc. 2014 - 2016. All rights reserved.
+
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Z.EntityFramework.Plus;
+
+namespace Z.Test.EntityFramework.Plus
+{
+    public partial class BatchDelete_WhereValue
+    {
+        [TestMethod]
+        public void False()
+        {
+            TestContext.DeleteAll(x => x.Entity_Basics);
+            TestContext.Insert(x => x.Entity_Basics, 50);
+
+            using (var ctx = new TestContext())
+            {
+                // BEFORE
+                Assert.AreEqual(1225, ctx.Entity_Basics.Sum(x => x.ColumnInt));
+
+                // ACTION
+                var rowsAffected = ctx.Entity_Basics.Where(x => false).Delete();
+
+                // AFTER
+                Assert.AreEqual(1225, ctx.Entity_Basics.Sum(x => x.ColumnInt));
+                Assert.AreEqual(0, rowsAffected);
+            }
+        }
+    }
+}

--- a/src/test/Z.Test.EntityFramework.Plus.EF6/Z.Test.EntityFramework.Plus.EF6.csproj
+++ b/src/test/Z.Test.EntityFramework.Plus.EF6/Z.Test.EntityFramework.Plus.EF6.csproj
@@ -157,6 +157,7 @@
     <Compile Include="BatchDelete\InMemory\Twenty.cs" />
     <Compile Include="BatchDelete\PrimaryKey\Single.cs" />
     <Compile Include="BatchDelete\PrimaryKey\Many.cs" />
+    <Compile Include="BatchDelete\WhereValue\False.cs" />
     <Compile Include="BatchDelete\WhereValue\Many_Constant.cs" />
     <Compile Include="BatchDelete\WhereValue\Many_Variable.cs" />
     <Compile Include="BatchDelete\WhereValue\Single_Constant.cs" />


### PR DESCRIPTION
The Delete method fails with a `System.Data.SqlClient.SqlException` when the where clause evaluates to false. Obviously, it would be better not to call the Delete method at all if the expression is known to evaluate to false but I think it should not fail nonetheless.

I would love to propose a solution to this issue but unfortunately, I'm not yet familiar enough with LINQ to Entities.