### PR TITLE
Decide if the delete or update commands must be executed based on the evaluated where clause

### DIFF
--- a/src/Z.EntityFramework.Plus.EF5.NET40/BatchDelete/BatchDelete.cs
+++ b/src/Z.EntityFramework.Plus.EF5.NET40/BatchDelete/BatchDelete.cs
@@ -133,11 +133,6 @@ SELECT  @totalRowAffected
         /// <returns>The number of rows affected.</returns>
         public int Execute<T>(IQueryable<T> query) where T : class
         {
-            if (query.Expression.ToString().Contains(".Where(x => False)"))
-            {
-                return 0;
-            }
-         
             // GET model and info
 #if EF5 || EF6
             var model = query.GetDbContext().GetModel();
@@ -150,6 +145,10 @@ SELECT  @totalRowAffected
              
             // CREATE command
             var command = CreateCommand(innerObjectQuery, entity);
+            if (command == null)
+            {
+                return 0;
+            }
 
             // EXECUTE
             var ownConnection = false;
@@ -319,6 +318,10 @@ SELECT  @totalRowAffected
 
             // GET inner query
             var querySelect = query.ToTraceString();
+            if (querySelect.EndsWith("WHERE 1 = 0"))
+            {
+                return null;
+            }
 
             // GET primary key join
             var primaryKeys = string.Join(Environment.NewLine + "AND ", columnKeys.Select(x => string.Concat("A.", EscapeName(x, isMySql), " = B.", EscapeName(x, isMySql), "")));

--- a/src/Z.EntityFramework.Plus.EF5.NET40/BatchUpdate/BatchUpdate.cs
+++ b/src/Z.EntityFramework.Plus.EF5.NET40/BatchUpdate/BatchUpdate.cs
@@ -127,11 +127,6 @@ SELECT  @totalRowAffected
         /// <returns>The number of rows affected.</returns>
         public int Execute<T>(IQueryable<T> query, Expression<Func<T, T>> updateFactory) where T : class
         {
-            if (query.Expression.ToString().Contains(".Where(x => False)"))
-            {
-                return 0;
-            }
-
 #if EF5 || EF6
             var objectQuery = query.GetObjectQuery();
 
@@ -150,6 +145,10 @@ SELECT  @totalRowAffected
 
             // CREATE command
             var command = CreateCommand(innerObjectQuery, entity, values);
+            if (command == null)
+            {
+                return 0;
+            }
 
             // EXECUTE
             var ownConnection = false;
@@ -277,6 +276,10 @@ SELECT  @totalRowAffected
 
             // GET inner query
             var querySelect = query.ToTraceString();
+            if (querySelect.EndsWith("WHERE 1 = 0"))
+            {
+                return null;
+            }
 
             // GET primary key join
             var primaryKeys = string.Join(Environment.NewLine + "AND ", columnKeys.Select(x => string.Concat("A.", EscapeName(x, isMySql), " = B.", EscapeName(x, isMySql), "")));

--- a/src/Z.EntityFramework.Plus.EF5/BatchDelete/BatchDelete.cs
+++ b/src/Z.EntityFramework.Plus.EF5/BatchDelete/BatchDelete.cs
@@ -133,11 +133,6 @@ SELECT  @totalRowAffected
         /// <returns>The number of rows affected.</returns>
         public int Execute<T>(IQueryable<T> query) where T : class
         {
-            if (query.Expression.ToString().Contains(".Where(x => False)"))
-            {
-                return 0;
-            }
-         
             // GET model and info
 #if EF5 || EF6
             var model = query.GetDbContext().GetModel();
@@ -150,6 +145,10 @@ SELECT  @totalRowAffected
              
             // CREATE command
             var command = CreateCommand(innerObjectQuery, entity);
+            if (command == null)
+            {
+                return 0;
+            }
 
             // EXECUTE
             var ownConnection = false;
@@ -319,6 +318,10 @@ SELECT  @totalRowAffected
 
             // GET inner query
             var querySelect = query.ToTraceString();
+            if (querySelect.EndsWith("WHERE 1 = 0"))
+            {
+                return null;
+            }
 
             // GET primary key join
             var primaryKeys = string.Join(Environment.NewLine + "AND ", columnKeys.Select(x => string.Concat("A.", EscapeName(x, isMySql), " = B.", EscapeName(x, isMySql), "")));

--- a/src/Z.EntityFramework.Plus.EF5/BatchUpdate/BatchUpdate.cs
+++ b/src/Z.EntityFramework.Plus.EF5/BatchUpdate/BatchUpdate.cs
@@ -127,11 +127,6 @@ SELECT  @totalRowAffected
         /// <returns>The number of rows affected.</returns>
         public int Execute<T>(IQueryable<T> query, Expression<Func<T, T>> updateFactory) where T : class
         {
-            if (query.Expression.ToString().Contains(".Where(x => False)"))
-            {
-                return 0;
-            }
-
 #if EF5 || EF6
             var objectQuery = query.GetObjectQuery();
 
@@ -150,6 +145,10 @@ SELECT  @totalRowAffected
 
             // CREATE command
             var command = CreateCommand(innerObjectQuery, entity, values);
+            if (command == null)
+            {
+                return 0;
+            }
 
             // EXECUTE
             var ownConnection = false;
@@ -277,6 +276,10 @@ SELECT  @totalRowAffected
 
             // GET inner query
             var querySelect = query.ToTraceString();
+            if (querySelect.EndsWith("WHERE 1 = 0"))
+            {
+                return null;
+            }
 
             // GET primary key join
             var primaryKeys = string.Join(Environment.NewLine + "AND ", columnKeys.Select(x => string.Concat("A.", EscapeName(x, isMySql), " = B.", EscapeName(x, isMySql), "")));

--- a/src/Z.EntityFramework.Plus.EF6.NET40/BatchDelete/BatchDelete.cs
+++ b/src/Z.EntityFramework.Plus.EF6.NET40/BatchDelete/BatchDelete.cs
@@ -133,11 +133,6 @@ SELECT  @totalRowAffected
         /// <returns>The number of rows affected.</returns>
         public int Execute<T>(IQueryable<T> query) where T : class
         {
-            if (query.Expression.ToString().Contains(".Where(x => False)"))
-            {
-                return 0;
-            }
-         
             // GET model and info
 #if EF5 || EF6
             var model = query.GetDbContext().GetModel();
@@ -150,6 +145,10 @@ SELECT  @totalRowAffected
              
             // CREATE command
             var command = CreateCommand(innerObjectQuery, entity);
+            if (command == null)
+            {
+                return 0;
+            }
 
             // EXECUTE
             var ownConnection = false;
@@ -319,6 +318,10 @@ SELECT  @totalRowAffected
 
             // GET inner query
             var querySelect = query.ToTraceString();
+            if (querySelect.EndsWith("WHERE 1 = 0"))
+            {
+                return null;
+            }
 
             // GET primary key join
             var primaryKeys = string.Join(Environment.NewLine + "AND ", columnKeys.Select(x => string.Concat("A.", EscapeName(x, isMySql), " = B.", EscapeName(x, isMySql), "")));

--- a/src/Z.EntityFramework.Plus.EF6.NET40/BatchUpdate/BatchUpdate.cs
+++ b/src/Z.EntityFramework.Plus.EF6.NET40/BatchUpdate/BatchUpdate.cs
@@ -127,11 +127,6 @@ SELECT  @totalRowAffected
         /// <returns>The number of rows affected.</returns>
         public int Execute<T>(IQueryable<T> query, Expression<Func<T, T>> updateFactory) where T : class
         {
-            if (query.Expression.ToString().Contains(".Where(x => False)"))
-            {
-                return 0;
-            }
-
 #if EF5 || EF6
             var objectQuery = query.GetObjectQuery();
 
@@ -150,6 +145,10 @@ SELECT  @totalRowAffected
 
             // CREATE command
             var command = CreateCommand(innerObjectQuery, entity, values);
+            if (command == null)
+            {
+                return 0;
+            }
 
             // EXECUTE
             var ownConnection = false;
@@ -277,6 +276,10 @@ SELECT  @totalRowAffected
 
             // GET inner query
             var querySelect = query.ToTraceString();
+            if (querySelect.EndsWith("WHERE 1 = 0"))
+            {
+                return null;
+            }
 
             // GET primary key join
             var primaryKeys = string.Join(Environment.NewLine + "AND ", columnKeys.Select(x => string.Concat("A.", EscapeName(x, isMySql), " = B.", EscapeName(x, isMySql), "")));

--- a/src/Z.EntityFramework.Plus.EF6/BatchDelete/BatchDelete.cs
+++ b/src/Z.EntityFramework.Plus.EF6/BatchDelete/BatchDelete.cs
@@ -133,11 +133,6 @@ SELECT  @totalRowAffected
         /// <returns>The number of rows affected.</returns>
         public int Execute<T>(IQueryable<T> query) where T : class
         {
-            if (query.Expression.ToString().Contains(".Where(x => False)"))
-            {
-                return 0;
-            }
-         
             // GET model and info
 #if EF5 || EF6
             var model = query.GetDbContext().GetModel();
@@ -150,6 +145,10 @@ SELECT  @totalRowAffected
              
             // CREATE command
             var command = CreateCommand(innerObjectQuery, entity);
+            if (command == null)
+            {
+                return 0;
+            }
 
             // EXECUTE
             var ownConnection = false;
@@ -319,6 +318,10 @@ SELECT  @totalRowAffected
 
             // GET inner query
             var querySelect = query.ToTraceString();
+            if (querySelect.EndsWith("WHERE 1 = 0"))
+            {
+                return null;
+            }
 
             // GET primary key join
             var primaryKeys = string.Join(Environment.NewLine + "AND ", columnKeys.Select(x => string.Concat("A.", EscapeName(x, isMySql), " = B.", EscapeName(x, isMySql), "")));

--- a/src/Z.EntityFramework.Plus.EF6/BatchUpdate/BatchUpdate.cs
+++ b/src/Z.EntityFramework.Plus.EF6/BatchUpdate/BatchUpdate.cs
@@ -127,11 +127,6 @@ SELECT  @totalRowAffected
         /// <returns>The number of rows affected.</returns>
         public int Execute<T>(IQueryable<T> query, Expression<Func<T, T>> updateFactory) where T : class
         {
-            if (query.Expression.ToString().Contains(".Where(x => False)"))
-            {
-                return 0;
-            }
-
 #if EF5 || EF6
             var objectQuery = query.GetObjectQuery();
 
@@ -150,6 +145,10 @@ SELECT  @totalRowAffected
 
             // CREATE command
             var command = CreateCommand(innerObjectQuery, entity, values);
+            if (command == null)
+            {
+                return 0;
+            }
 
             // EXECUTE
             var ownConnection = false;
@@ -277,6 +276,10 @@ SELECT  @totalRowAffected
 
             // GET inner query
             var querySelect = query.ToTraceString();
+            if (querySelect.EndsWith("WHERE 1 = 0"))
+            {
+                return null;
+            }
 
             // GET primary key join
             var primaryKeys = string.Join(Environment.NewLine + "AND ", columnKeys.Select(x => string.Concat("A.", EscapeName(x, isMySql), " = B.", EscapeName(x, isMySql), "")));

--- a/src/Z.EntityFramework.Plus.EFCore/BatchDelete/BatchDelete.cs
+++ b/src/Z.EntityFramework.Plus.EFCore/BatchDelete/BatchDelete.cs
@@ -133,11 +133,6 @@ SELECT  @totalRowAffected
         /// <returns>The number of rows affected.</returns>
         public int Execute<T>(IQueryable<T> query) where T : class
         {
-            if (query.Expression.ToString().Contains(".Where(x => False)"))
-            {
-                return 0;
-            }
-         
             // GET model and info
 #if EF5 || EF6
             var model = query.GetDbContext().GetModel();
@@ -233,6 +228,10 @@ SELECT  @totalRowAffected
 
             // CREATE command
             var command = CreateCommand(queryKeys, entity);
+            if (command == null)
+            {
+                return 0;
+            }
 
             // EXECUTE
             var ownConnection = false;
@@ -488,6 +487,10 @@ SELECT  @totalRowAffected
                 var relationalCommand = query.CreateCommand();
 #endif
                 var querySelect = relationalCommand.CommandText;
+                if (querySelect.EndsWith("WHERE 1 = 0"))
+                {
+                    return null;
+                }
 
                 // GET primary key join
                 var primaryKeys = string.Join(Environment.NewLine + "AND ", columnKeys.Select(x => string.Concat("A.[", x, "] = B.[", x, "]")));

--- a/src/Z.EntityFramework.Plus.EFCore/BatchUpdate/BatchUpdate.cs
+++ b/src/Z.EntityFramework.Plus.EFCore/BatchUpdate/BatchUpdate.cs
@@ -127,11 +127,6 @@ SELECT  @totalRowAffected
         /// <returns>The number of rows affected.</returns>
         public int Execute<T>(IQueryable<T> query, Expression<Func<T, T>> updateFactory) where T : class
         {
-            if (query.Expression.ToString().Contains(".Where(x => False)"))
-            {
-                return 0;
-            }
-
 #if EF5 || EF6
             var objectQuery = query.GetObjectQuery();
 
@@ -192,6 +187,10 @@ SELECT  @totalRowAffected
 
             // CREATE command
             var command = CreateCommand(queryKeys, entity, values);
+            if (command == null)
+            {
+                return 0;
+            }
 
             // EXECUTE
             var ownConnection = false;
@@ -402,6 +401,10 @@ SELECT  @totalRowAffected
                 var relationalCommand = query.CreateCommand();
 #endif
                 var querySelect = relationalCommand.CommandText;
+                if (querySelect.EndsWith("WHERE 1 = 0"))
+                {
+                    return null;
+                }
 
                 // GET primary key join
                 var primaryKeys = string.Join(Environment.NewLine + "AND ", columnKeys.Select(x => string.Concat("A.[", x, "] = B.[", x, "]")));

--- a/src/test/Z.Test.EntityFramework.Plus.EF5/BatchUpdate/WhereValue/Single_False.cs
+++ b/src/test/Z.Test.EntityFramework.Plus.EF5/BatchUpdate/WhereValue/Single_False.cs
@@ -14,7 +14,7 @@ namespace Z.Test.EntityFramework.Plus
     public partial class BatchUpdate_WhereValue
     {
         [TestMethod]
-        public void False()
+        public void Single_False()
         {
             TestContext.DeleteAll(x => x.Entity_Basics);
             TestContext.Insert(x => x.Entity_Basics, 50);

--- a/src/test/Z.Test.EntityFramework.Plus.EFCore/BatchUpdate/WhereValue/Single_False.cs
+++ b/src/test/Z.Test.EntityFramework.Plus.EFCore/BatchUpdate/WhereValue/Single_False.cs
@@ -14,7 +14,7 @@ namespace Z.Test.EntityFramework.Plus
     public partial class BatchUpdate_WhereValue
     {
         [TestMethod]
-        public void False()
+        public void Single_False()
         {
             TestContext.DeleteAll(x => x.Entity_Basics);
             TestContext.Insert(x => x.Entity_Basics, 50);


### PR DESCRIPTION
There are infinite ways a where clause could evaluate to false, only checking for `.Where(x => False)` is not enough. Let LINQ to Entities evaluate the select query instead.