### PR TITLE
Include command tree interceptor values in GetCommandTextAndParameters()

### DIFF
--- a/src/Z.EntityFramework.Plus.EF5.NET40/_Internal/EF6/ObjectQuery/GetCommandTextAndParameters.cs
+++ b/src/Z.EntityFramework.Plus.EF5.NET40/_Internal/EF6/ObjectQuery/GetCommandTextAndParameters.cs
@@ -8,9 +8,11 @@
 #if FULL || QUERY_CACHE || QUERY_FILTER
 #if EF6
 using System;
+using System.Collections.Generic;
 using System.Data.Common;
 using System.Data.Entity.Core.EntityClient;
 using System.Data.Entity.Core.Objects;
+using System.Data.Entity.Infrastructure.Interception;
 using System.Reflection;
 
 namespace Z.EntityFramework.Plus
@@ -33,6 +35,14 @@ namespace Z.EntityFramework.Plus
 
                 var prepareEntityCommandBeforeExecutionMethod = getCommandDefinition.GetType().GetMethod("PrepareEntityCommandBeforeExecution", BindingFlags.NonPublic | BindingFlags.Instance);
                 var prepareEntityCommandBeforeExecution = (DbCommand) prepareEntityCommandBeforeExecutionMethod.Invoke(getCommandDefinition, new object[] {entityCommand});
+
+                var commandDispatcherField = DbInterception.Dispatch.Command.GetType().GetField("_internalDispatcher", BindingFlags.Instance | BindingFlags.NonPublic);
+                var commandDispatcher = commandDispatcherField.GetValue(DbInterception.Dispatch.Command);
+
+                var interceptorsField = commandDispatcher.GetType().GetField("_interceptors", BindingFlags.Instance | BindingFlags.NonPublic);
+                var interceptors = (List<IDbCommandInterceptor>) interceptorsField.GetValue(commandDispatcher);
+
+                interceptors.ForEach(i => i.ReaderExecuting(prepareEntityCommandBeforeExecution, new DbCommandInterceptionContext<DbDataReader>(objectQuery.Context.GetInterceptionContext())));
 
                 sql = prepareEntityCommandBeforeExecution.CommandText;
                 var parameters = prepareEntityCommandBeforeExecution.Parameters;

--- a/src/Z.EntityFramework.Plus.EF5/_Internal/EF6/ObjectQuery/GetCommandTextAndParameters.cs
+++ b/src/Z.EntityFramework.Plus.EF5/_Internal/EF6/ObjectQuery/GetCommandTextAndParameters.cs
@@ -8,9 +8,11 @@
 #if FULL || QUERY_CACHE || QUERY_FILTER
 #if EF6
 using System;
+using System.Collections.Generic;
 using System.Data.Common;
 using System.Data.Entity.Core.EntityClient;
 using System.Data.Entity.Core.Objects;
+using System.Data.Entity.Infrastructure.Interception;
 using System.Reflection;
 
 namespace Z.EntityFramework.Plus
@@ -33,6 +35,14 @@ namespace Z.EntityFramework.Plus
 
                 var prepareEntityCommandBeforeExecutionMethod = getCommandDefinition.GetType().GetMethod("PrepareEntityCommandBeforeExecution", BindingFlags.NonPublic | BindingFlags.Instance);
                 var prepareEntityCommandBeforeExecution = (DbCommand) prepareEntityCommandBeforeExecutionMethod.Invoke(getCommandDefinition, new object[] {entityCommand});
+
+                var commandDispatcherField = DbInterception.Dispatch.Command.GetType().GetField("_internalDispatcher", BindingFlags.Instance | BindingFlags.NonPublic);
+                var commandDispatcher = commandDispatcherField.GetValue(DbInterception.Dispatch.Command);
+
+                var interceptorsField = commandDispatcher.GetType().GetField("_interceptors", BindingFlags.Instance | BindingFlags.NonPublic);
+                var interceptors = (List<IDbCommandInterceptor>) interceptorsField.GetValue(commandDispatcher);
+
+                interceptors.ForEach(i => i.ReaderExecuting(prepareEntityCommandBeforeExecution, new DbCommandInterceptionContext<DbDataReader>(objectQuery.Context.GetInterceptionContext())));
 
                 sql = prepareEntityCommandBeforeExecution.CommandText;
                 var parameters = prepareEntityCommandBeforeExecution.Parameters;

--- a/src/Z.EntityFramework.Plus.EF6.NET40/_Internal/EF6/ObjectQuery/GetCommandTextAndParameters.cs
+++ b/src/Z.EntityFramework.Plus.EF6.NET40/_Internal/EF6/ObjectQuery/GetCommandTextAndParameters.cs
@@ -8,9 +8,11 @@
 #if FULL || QUERY_CACHE || QUERY_FILTER
 #if EF6
 using System;
+using System.Collections.Generic;
 using System.Data.Common;
 using System.Data.Entity.Core.EntityClient;
 using System.Data.Entity.Core.Objects;
+using System.Data.Entity.Infrastructure.Interception;
 using System.Reflection;
 
 namespace Z.EntityFramework.Plus
@@ -33,6 +35,14 @@ namespace Z.EntityFramework.Plus
 
                 var prepareEntityCommandBeforeExecutionMethod = getCommandDefinition.GetType().GetMethod("PrepareEntityCommandBeforeExecution", BindingFlags.NonPublic | BindingFlags.Instance);
                 var prepareEntityCommandBeforeExecution = (DbCommand) prepareEntityCommandBeforeExecutionMethod.Invoke(getCommandDefinition, new object[] {entityCommand});
+
+                var commandDispatcherField = DbInterception.Dispatch.Command.GetType().GetField("_internalDispatcher", BindingFlags.Instance | BindingFlags.NonPublic);
+                var commandDispatcher = commandDispatcherField.GetValue(DbInterception.Dispatch.Command);
+
+                var interceptorsField = commandDispatcher.GetType().GetField("_interceptors", BindingFlags.Instance | BindingFlags.NonPublic);
+                var interceptors = (List<IDbCommandInterceptor>) interceptorsField.GetValue(commandDispatcher);
+
+                interceptors.ForEach(i => i.ReaderExecuting(prepareEntityCommandBeforeExecution, new DbCommandInterceptionContext<DbDataReader>(objectQuery.Context.GetInterceptionContext())));
 
                 sql = prepareEntityCommandBeforeExecution.CommandText;
                 var parameters = prepareEntityCommandBeforeExecution.Parameters;

--- a/src/Z.EntityFramework.Plus.EF6/_Internal/EF6/ObjectQuery/GetCommandTextAndParameters.cs
+++ b/src/Z.EntityFramework.Plus.EF6/_Internal/EF6/ObjectQuery/GetCommandTextAndParameters.cs
@@ -8,9 +8,11 @@
 #if FULL || QUERY_CACHE || QUERY_FILTER
 #if EF6
 using System;
+using System.Collections.Generic;
 using System.Data.Common;
 using System.Data.Entity.Core.EntityClient;
 using System.Data.Entity.Core.Objects;
+using System.Data.Entity.Infrastructure.Interception;
 using System.Reflection;
 
 namespace Z.EntityFramework.Plus
@@ -33,6 +35,14 @@ namespace Z.EntityFramework.Plus
 
                 var prepareEntityCommandBeforeExecutionMethod = getCommandDefinition.GetType().GetMethod("PrepareEntityCommandBeforeExecution", BindingFlags.NonPublic | BindingFlags.Instance);
                 var prepareEntityCommandBeforeExecution = (DbCommand) prepareEntityCommandBeforeExecutionMethod.Invoke(getCommandDefinition, new object[] {entityCommand});
+
+                var commandDispatcherField = DbInterception.Dispatch.Command.GetType().GetField("_internalDispatcher", BindingFlags.Instance | BindingFlags.NonPublic);
+                var commandDispatcher = commandDispatcherField.GetValue(DbInterception.Dispatch.Command);
+
+                var interceptorsField = commandDispatcher.GetType().GetField("_interceptors", BindingFlags.Instance | BindingFlags.NonPublic);
+                var interceptors = (List<IDbCommandInterceptor>) interceptorsField.GetValue(commandDispatcher);
+
+                interceptors.ForEach(i => i.ReaderExecuting(prepareEntityCommandBeforeExecution, new DbCommandInterceptionContext<DbDataReader>(objectQuery.Context.GetInterceptionContext())));
 
                 sql = prepareEntityCommandBeforeExecution.CommandText;
                 var parameters = prepareEntityCommandBeforeExecution.Parameters;

--- a/src/Z.EntityFramework.Plus.EFCore/_Internal/EF6/ObjectQuery/GetCommandTextAndParameters.cs
+++ b/src/Z.EntityFramework.Plus.EFCore/_Internal/EF6/ObjectQuery/GetCommandTextAndParameters.cs
@@ -8,9 +8,11 @@
 #if FULL || QUERY_CACHE || QUERY_FILTER
 #if EF6
 using System;
+using System.Collections.Generic;
 using System.Data.Common;
 using System.Data.Entity.Core.EntityClient;
 using System.Data.Entity.Core.Objects;
+using System.Data.Entity.Infrastructure.Interception;
 using System.Reflection;
 
 namespace Z.EntityFramework.Plus
@@ -33,6 +35,14 @@ namespace Z.EntityFramework.Plus
 
                 var prepareEntityCommandBeforeExecutionMethod = getCommandDefinition.GetType().GetMethod("PrepareEntityCommandBeforeExecution", BindingFlags.NonPublic | BindingFlags.Instance);
                 var prepareEntityCommandBeforeExecution = (DbCommand) prepareEntityCommandBeforeExecutionMethod.Invoke(getCommandDefinition, new object[] {entityCommand});
+
+                var commandDispatcherField = DbInterception.Dispatch.Command.GetType().GetField("_internalDispatcher", BindingFlags.Instance | BindingFlags.NonPublic);
+                var commandDispatcher = commandDispatcherField.GetValue(DbInterception.Dispatch.Command);
+
+                var interceptorsField = commandDispatcher.GetType().GetField("_interceptors", BindingFlags.Instance | BindingFlags.NonPublic);
+                var interceptors = (List<IDbCommandInterceptor>) interceptorsField.GetValue(commandDispatcher);
+
+                interceptors.ForEach(i => i.ReaderExecuting(prepareEntityCommandBeforeExecution, new DbCommandInterceptionContext<DbDataReader>(objectQuery.Context.GetInterceptionContext())));
 
                 sql = prepareEntityCommandBeforeExecution.CommandText;
                 var parameters = prepareEntityCommandBeforeExecution.Parameters;


### PR DESCRIPTION
I use multiple IDbCommandInterceptor's in my project. For example for multi-tenancy.

I was testing out EFPlus caching (in EF6 net462), and I noticed that the cached value will be used when I change the value used in my interceptor. This should of course not happen, because the database would return different data, because the query changed.

When I inspected the generated cache key, I noticed the value property of the used DbParameters was actually empty. Which turned out to be because the interceptor had not yet ran yet.

I could sadly find no public properties to retrieve the interceptors. So I used reflection (which was used already anyway) to obtain the interceptors and run them.

I can provide a sample project to demonstrate the usage more clearly, if you would like me to.
Let me know what you think! :)