### PR TITLE
Migrate CreateCommand to DotNetCore 2.0.0 preview2

### DIFF
--- a/src/Z.EntityFramework.Plus.EFCore.NETStandard/Z.EntityFramework.Plus.EFCore.NETStandard.csproj
+++ b/src/Z.EntityFramework.Plus.EFCore.NETStandard/Z.EntityFramework.Plus.EFCore.NETStandard.csproj
@@ -8,9 +8,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.3</TargetFramework>
-    <SignAssembly>True</SignAssembly>
-    <AssemblyOriginatorKeyFile>zzzproject.pfx</AssemblyOriginatorKeyFile>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <SignAssembly>False</SignAssembly>
     <DelaySign>False</DelaySign>
     <Version>1.6.0</Version>
     <Description>Description: EF Bulk Operations &amp; Utilities | Bulk Insert, Update, Delete, Merge from database.</Description>
@@ -28,7 +27,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="1.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.0.0-preview2-final" />
     <PackageReference Include="System.Reflection.Emit" Version="4.0.1" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.1.0" />
   </ItemGroup>


### PR DESCRIPTION
Some signatures of private methods in the QueryCompiler in Microsoft.EntityFrameworkCore have been migrated to non-static, and were breaking at runtime in the CreateCommand extension class.

I also had to remove the PFX signing in the project, as it seems not to be supported by DotNet core (I end up with the following error at compile time: `C:\Program Files\dotnet\sdk\2.0.0-preview2-006497\Microsoft.Common.CurrentVersion.targets(3086,5): error : PFX signing not supported on .NET Core [F:\otherstuff\EntityFramework-Plus\src\Z.EntityFramework.Plus.EFCore.NETStandard\Z.EntityFramework.Plus.EFCore.NETStandard.csproj]` ).

Cheers,
Thibault