### PR TITLE
Add implicit conversion from QueryFutureValue to T

### DIFF
--- a/src/shared/Z.EF.Plus.QueryFuture.Shared/QueryFutureValue.cs
+++ b/src/shared/Z.EF.Plus.QueryFuture.Shared/QueryFutureValue.cs
@@ -115,5 +115,15 @@ namespace Z.EntityFramework.Plus
             _result = value;
             HasValue = true;
         }
+        
+        /// <summary>
+        /// Performs an implicit conversion from QueryFutureValue to T.
+        /// </summary>
+        /// <param name="futureValue">The future value.</param>
+        /// <returns>The result of forcing this lazy value.</returns>
+        public static implicit operator T(QueryFutureValue<T> futureValue)
+        {
+            return futureValue.Value;
+        }
     }
 }


### PR DESCRIPTION
It was very convenient to have implicit conversion in the old EF.Extended, can we have the same here?