### PR TITLE
Fix formatting old-values when modifying entities

### DIFF
--- a/src/shared/Z.EF.Plus.Audit.Shared/AuditConfiguration/FormatValue.cs
+++ b/src/shared/Z.EF.Plus.Audit.Shared/AuditConfiguration/FormatValue.cs
@@ -38,7 +38,11 @@ namespace Z.EntityFramework.Plus
         {
             if (EntityValueFormatters.Count > 0)
             {
+#if EF5 || EF6
+                var type = ObjectContext.GetObjectType(entity.GetType());
+#elif EFCORE
                 var type = entity.GetType();
+#endif
                 var key = string.Concat(type.FullName, ";", propertyName);
                 Func<object, object> formatter;
 


### PR DESCRIPTION
FormatValue seems to work only on NewValue, as in this case the passed object entity is a POCO. Otherwise the passed entity seems to be a proxy, which has a different type. Only tested with EF6, EFCORE needs rework (?).