### PR TITLE
Implemented in memory check for Effort in EF6

### DIFF
--- a/src/Z.EntityFramework.Plus.EF6/Z.EntityFramework.Plus.EF6.csproj
+++ b/src/Z.EntityFramework.Plus.EF6/Z.EntityFramework.Plus.EF6.csproj
@@ -37,16 +37,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Effort, Version=1.0.0.0, Culture=neutral, PublicKeyToken=6a46696d54971e6d, processorArchitecture=MSIL">
-      <HintPath>..\packages\Effort.EF6.1.3.0\lib\net45\Effort.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\packages\EntityFramework.6.0.0\lib\net45\EntityFramework.dll</HintPath>
-    </Reference>
-    <Reference Include="NMemory, Version=1.0.0.0, Culture=neutral, PublicKeyToken=6a46696d54971e6d, processorArchitecture=MSIL">
-      <HintPath>..\packages\NMemory.1.1.0\lib\net45\NMemory.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/src/Z.EntityFramework.Plus.EF6/Z.EntityFramework.Plus.EF6.csproj
+++ b/src/Z.EntityFramework.Plus.EF6/Z.EntityFramework.Plus.EF6.csproj
@@ -37,14 +37,23 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Effort, Version=1.0.0.0, Culture=neutral, PublicKeyToken=6a46696d54971e6d, processorArchitecture=MSIL">
+      <HintPath>..\packages\Effort.EF6.1.3.0\lib\net45\Effort.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\packages\EntityFramework.6.0.0\lib\net45\EntityFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="NMemory, Version=1.0.0.0, Culture=neutral, PublicKeyToken=6a46696d54971e6d, processorArchitecture=MSIL">
+      <HintPath>..\packages\NMemory.1.1.0\lib\net45\NMemory.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
     <Reference Include="System.Runtime.Caching" />
     <Reference Include="System.Runtime.Extensions" />
+    <Reference Include="System.Transactions" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/Z.EntityFramework.Plus.EF6/packages.config
+++ b/src/Z.EntityFramework.Plus.EF6/packages.config
@@ -1,6 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Effort.EF6" version="1.3.0" targetFramework="net45" />
   <package id="EntityFramework" version="6.0.0" targetFramework="net45" />
-  <package id="NMemory" version="1.1.0" targetFramework="net45" />
 </packages>

--- a/src/Z.EntityFramework.Plus.EF6/packages.config
+++ b/src/Z.EntityFramework.Plus.EF6/packages.config
@@ -1,4 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Effort.EF6" version="1.3.0" targetFramework="net45" />
   <package id="EntityFramework" version="6.0.0" targetFramework="net45" />
+  <package id="NMemory" version="1.1.0" targetFramework="net45" />
 </packages>

--- a/src/shared/Z.EF.Plus.BatchDelete.Shared/BatchDelete.cs
+++ b/src/shared/Z.EF.Plus.BatchDelete.Shared/BatchDelete.cs
@@ -185,7 +185,19 @@ SELECT  @totalRowAffected
             {
                 return 0;
             }
-         
+
+#if EF6
+            if (query.IsInMemoryEffortQueryContext())
+            {
+                var context = query.GetDbContext();
+
+                var list = query.ToList();
+                context.Set<T>().RemoveRange(list);
+                context.SaveChanges();
+                return list.Count;
+            }
+#endif
+
             // GET model and info
 #if EF5 || EF6
             var dbContext = query.GetDbContext();

--- a/src/shared/Z.EF.Plus._Core.Shared/EF6/IQueryable`/IsInMemoryEffortQueryContext.cs
+++ b/src/shared/Z.EF.Plus._Core.Shared/EF6/IQueryable`/IsInMemoryEffortQueryContext.cs
@@ -1,0 +1,19 @@
+﻿
+#if EF6
+using System;
+using System.Data.Entity;
+using System.Linq;
+using System.Reflection;
+
+namespace Z.EntityFramework.Plus
+{
+    internal static partial class InternalExtensions
+    {
+        public static bool IsInMemoryEffortQueryContext<T>(this IQueryable<T> q)
+        {
+            return q.GetDbContext().Database.Connection is Effort.Provider.EffortConnection;
+        }
+    }
+}
+
+#endif

--- a/src/shared/Z.EF.Plus._Core.Shared/EF6/IQueryable`/IsInMemoryEffortQueryContext.cs
+++ b/src/shared/Z.EF.Plus._Core.Shared/EF6/IQueryable`/IsInMemoryEffortQueryContext.cs
@@ -11,7 +11,7 @@ namespace Z.EntityFramework.Plus
     {
         public static bool IsInMemoryEffortQueryContext<T>(this IQueryable<T> q)
         {
-            return q.GetDbContext().Database.Connection is Effort.Provider.EffortConnection;
+            return q.GetDbContext().Database.Connection.GetType().FullName == "Effort.Provider.EffortConnection";
         }
     }
 }

--- a/src/shared/Z.EF.Plus._Core.Shared/Z.EF.Plus._Core.Shared.projitems
+++ b/src/shared/Z.EF.Plus._Core.Shared/Z.EF.Plus._Core.Shared.projitems
@@ -38,6 +38,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)EF5_EF6\ObjectContext\CreateStoreCommand.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)EF5_EF6\ObjectContext\GetEntitySet.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)EF5_EF6\Object\Object.GetObjectQuery.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)EF6\IQueryable`\IsInMemoryEffortQueryContext.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)EF6\ObjectContext\GetDbContext.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)EF6\ObjectContext\GetInterceptionContext.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)EF6\ObjectQuery\GetCommandTextAndParameters.cs" />


### PR DESCRIPTION
Hi,

I was trying to use this extension on a project in EF6 with Effort.EF6 and I was getting a lot of exceptions. This PR is fixing all these problems, I basically created a condition to check if the connection is a EffortConnection. This way the unit test should not break.

I know that this could not be the best solution for this case and you can reject this PR if you want. Also, I can create an issue regarding this problem so we can discuss the best solution.