### PR TITLE
fixes # 285 BatchUpdate when an entity's field has a property of enum type …

### DIFF
--- a/src/shared/Z.EF.Plus.BatchUpdate.Shared/BatchUpdate.cs
+++ b/src/shared/Z.EF.Plus.BatchUpdate.Shared/BatchUpdate.cs
@@ -574,9 +574,11 @@ SELECT  @totalRowAffected
                 }
                 else
                 {
-                    if (values[i].Item2.GetType().IsEnum)
+                    Type itemType = values[i].Item2.GetType();
+                    if (itemType.IsEnum)
                     {
-                        parameter.Value = (int) paramValue;
+                        var underlyingType = Enum.GetUnderlyingType(itemType);
+                        parameter.Value = Convert.ChangeType(paramValue, underlyingType);
                     }
                     else
                     {


### PR DESCRIPTION
…that derives from a type that differs from Int32 (e.g. byte, long etc.)