### PR TITLE
Remove Core references in EF5 conditional code

### DIFF
--- a/src/shared/Z.EF.Plus.Audit.Shared/Audit.cs
+++ b/src/shared/Z.EF.Plus.Audit.Shared/Audit.cs
@@ -61,7 +61,7 @@ namespace Z.EntityFramework.Plus
 
         public static object GetRelationshipEntryKey0(ObjectStateEntry entry)
         {
-            var relationshipEntryType = typeof(ObjectStateEntry).Assembly.GetType("System.Data.Entity.Core.Objects.RelationshipEntry");
+            var relationshipEntryType = typeof(ObjectStateEntry).Assembly.GetType("System.Data.Objects.RelationshipEntry");
 
             if (RelationshipEntryKey0 == null)
             {
@@ -82,7 +82,7 @@ namespace Z.EntityFramework.Plus
 
         public static object GetRelationshipEntryKey1(ObjectStateEntry entry)
         {
-            var relationshipEntryType = typeof(ObjectStateEntry).Assembly.GetType("System.Data.Entity.Core.Objects.RelationshipEntry");
+            var relationshipEntryType = typeof(ObjectStateEntry).Assembly.GetType("System.Data.Objects.RelationshipEntry");
 
             if (RelationshipEntryKey1 == null)
             {


### PR DESCRIPTION
A fix for #295

It's only tested on EF5. 