### PR TITLE
Fix/use simple update statements if possible 312

### DIFF
--- a/src/shared/Z.EF.Plus.BatchDelete.Shared/BatchDeleteVisitor.cs
+++ b/src/shared/Z.EF.Plus.BatchDelete.Shared/BatchDeleteVisitor.cs
@@ -32,24 +32,22 @@ namespace Z.EntityFramework.Plus
         /// </returns>
         protected override Expression VisitMethodCall(MethodCallExpression node)
         {
-            if (node.Method.Name == "OrderBy")
-            {
-                HasOrderBy = true;
-            }
-            else if (node.Method.Name == "Skip")
-            {
-                HasSkip = true;
-            }
-            else if (node.Method.Name == "Take")
-            {
-                HasTake = true;
-            }
-
             switch (node.Method.Name)
             {
+                case "OrderBy":
+                    HasOrderBy = true;
+                    break;
+                case "Skip":
+                    HasSkip = true;
+                    break;
+                case "Take":
+                    HasTake = true;
+                    break;
                 case "Join":
                 case "Select":
+                case "SelectMany":
                 case "Concat":
+                case "Union":
                 case "GroupBy":
                     IsSimpleQuery = false;
                     break;

--- a/src/shared/Z.EF.Plus.BatchDelete.Shared/BatchDeleteVisitor.cs
+++ b/src/shared/Z.EF.Plus.BatchDelete.Shared/BatchDeleteVisitor.cs
@@ -54,5 +54,15 @@ namespace Z.EntityFramework.Plus
             }
             return base.VisitMethodCall(node);
         }
+
+        protected override Expression VisitMember(MemberExpression node)
+        {
+            if (node.Expression?.GetType().Name == "PropertyExpression")
+            {
+                IsSimpleQuery = false;
+            }
+
+            return base.VisitMember(node);
+        }
     }
 }

--- a/src/shared/Z.EF.Plus.BatchDelete.Shared/BatchDeleteVisitor.cs
+++ b/src/shared/Z.EF.Plus.BatchDelete.Shared/BatchDeleteVisitor.cs
@@ -44,9 +44,15 @@ namespace Z.EntityFramework.Plus
             {
                 HasTake = true;
             }
-            if (node.Method.Name == "Join" || node.Method.Name == "Concat" || node.Method.Name == "GroupBy")
+
+            switch (node.Method.Name)
             {
-                IsSimpleQuery = false;
+                case "Join":
+                case "Select":
+                case "Concat":
+                case "GroupBy":
+                    IsSimpleQuery = false;
+                    break;
             }
             return base.VisitMethodCall(node);
         }

--- a/src/shared/Z.EF.Plus.BatchDelete.Shared/BatchDeleteVisitor.cs
+++ b/src/shared/Z.EF.Plus.BatchDelete.Shared/BatchDeleteVisitor.cs
@@ -18,6 +18,11 @@ namespace Z.EntityFramework.Plus
         public bool HasTake { get; set; }
 
         /// <summary>
+        /// True if a query is simple and references only one Entity, doesn't include unions etc.
+        /// </summary>
+        public bool IsSimpleQuery { get; set; } = true;
+
+        /// <summary>
         ///     Visits the children of the <see cref="T:System.Linq.Expressions.MethodCallExpression" />.
         /// </summary>
         /// <param name="node">The expression to visit.</param>
@@ -39,7 +44,10 @@ namespace Z.EntityFramework.Plus
             {
                 HasTake = true;
             }
-
+            if (node.Method.Name == "Join" || node.Method.Name == "Concat" || node.Method.Name == "GroupBy")
+            {
+                IsSimpleQuery = false;
+            }
             return base.VisitMethodCall(node);
         }
     }

--- a/src/shared/Z.EF.Plus.BatchUpdate.Shared/BatchUpdateVisitor.cs
+++ b/src/shared/Z.EF.Plus.BatchUpdate.Shared/BatchUpdateVisitor.cs
@@ -28,9 +28,15 @@ namespace Z.EntityFramework.Plus
             {
                 HasOrderBy = true;
             }
-            if (node.Method.Name == "Join" || node.Method.Name == "Concat" || node.Method.Name == "GroupBy")
+
+            switch (node.Method.Name)
             {
-                IsSimpleQuery = false;
+                case "Join":
+                case "Select":
+                case "Concat":
+                case "GroupBy":
+                    IsSimpleQuery = false;
+                    break;
             }
 
             return base.VisitMethodCall(node);

--- a/src/shared/Z.EF.Plus.BatchUpdate.Shared/BatchUpdateVisitor.cs
+++ b/src/shared/Z.EF.Plus.BatchUpdate.Shared/BatchUpdateVisitor.cs
@@ -41,5 +41,15 @@ namespace Z.EntityFramework.Plus
 
             return base.VisitMethodCall(node);
         }
+
+        protected override Expression VisitMember(MemberExpression node)
+        {
+            if (node.Expression?.GetType().Name == "PropertyExpression")
+            {
+                IsSimpleQuery = false;
+            }
+
+            return base.VisitMember(node);
+        }
     }
 }

--- a/src/shared/Z.EF.Plus.BatchUpdate.Shared/BatchUpdateVisitor.cs
+++ b/src/shared/Z.EF.Plus.BatchUpdate.Shared/BatchUpdateVisitor.cs
@@ -10,6 +10,11 @@ namespace Z.EntityFramework.Plus
         public bool HasOrderBy { get; set; }
 
         /// <summary>
+        /// True if a query is simple and references only one Entity, doesn't include unions etc.
+        /// </summary>
+        public bool IsSimpleQuery { get; set; } = true;
+
+        /// <summary>
         ///     Visits the children of the <see cref="T:System.Linq.Expressions.MethodCallExpression" />.
         /// </summary>
         /// <param name="node">The expression to visit.</param>
@@ -22,6 +27,10 @@ namespace Z.EntityFramework.Plus
             if (node.Method.Name == "OrderBy")
             {
                 HasOrderBy = true;
+            }
+            if (node.Method.Name == "Join" || node.Method.Name == "Concat" || node.Method.Name == "GroupBy")
+            {
+                IsSimpleQuery = false;
             }
 
             return base.VisitMethodCall(node);

--- a/src/shared/Z.EF.Plus.BatchUpdate.Shared/BatchUpdateVisitor.cs
+++ b/src/shared/Z.EF.Plus.BatchUpdate.Shared/BatchUpdateVisitor.cs
@@ -24,16 +24,16 @@ namespace Z.EntityFramework.Plus
         /// </returns>
         protected override Expression VisitMethodCall(MethodCallExpression node)
         {
-            if (node.Method.Name == "OrderBy")
-            {
-                HasOrderBy = true;
-            }
-
             switch (node.Method.Name)
             {
+                case "OrderBy":
+                    HasOrderBy = true;
+                    break;
                 case "Join":
                 case "Select":
+                case "SelectMany":
                 case "Concat":
+                case "Union":
                 case "GroupBy":
                     IsSimpleQuery = false;
                     break;

--- a/src/test/Z.Test.EntityFramework.Plus.EF6/BatchDelete/Visitor/DetectComplexQuery.cs
+++ b/src/test/Z.Test.EntityFramework.Plus.EF6/BatchDelete/Visitor/DetectComplexQuery.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Linq;
+using System.Linq.Expressions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Z.EntityFramework.Plus;
+
+namespace Z.Test.EntityFramework.Plus
+{
+    public partial class BatchDelete_Visitor
+    {
+        [TestMethod]
+        public void DetectNavigationPropertyAccess()
+        {
+            Expression<Func<Entity_Complex, bool>> expression = e => e.Info.ColumnInt > 3;
+            var visitor = new BatchDeleteVisitor();
+            visitor.Visit(expression);
+            Assert.IsFalse(visitor.IsSimpleQuery);
+        }
+
+        [TestMethod]
+        public void DetectNavigationPropertyAccess2()
+        {
+            Expression<Func<Entity_Complex, bool>> expression = e => e.ID > 3 && e.Info.ColumnInt > 3;
+            var visitor = new BatchDeleteVisitor();
+            visitor.Visit(expression);
+            Assert.IsFalse(visitor.IsSimpleQuery);
+        }
+
+        [TestMethod]
+        public void DetectJoinOnLetStatementOperator()
+        {
+            using (var ctx = new TestContext())
+            {
+                var z = from e in ctx.Entity_Complexes
+                    let k = e.Info.Info
+                    select e;
+
+                var expression = z.Expression;
+                var visitor = new BatchDeleteVisitor();
+                visitor.Visit(expression);
+                Assert.IsFalse(visitor.IsSimpleQuery);
+            }
+        }
+
+        [TestMethod]
+        public void DetectJoinOperator()
+        {
+            using (var ctx = new TestContext())
+            {
+                var z = from e in ctx.Entity_Complexes
+                    join p in ctx.Entity_Basics on e.ID equals p.ID
+                    select e;
+
+                var expression = z.Expression;
+                var visitor = new BatchDeleteVisitor();
+                visitor.Visit(expression);
+                Assert.IsFalse(visitor.IsSimpleQuery);
+            }
+        }
+    }
+}

--- a/src/test/Z.Test.EntityFramework.Plus.EF6/BatchDelete/Visitor/DetectSimpleQuery.cs
+++ b/src/test/Z.Test.EntityFramework.Plus.EF6/BatchDelete/Visitor/DetectSimpleQuery.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Linq.Expressions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Z.EntityFramework.Plus;
+
+namespace Z.Test.EntityFramework.Plus
+{
+    public partial class BatchDelete_Visitor
+    {
+        [TestMethod]
+        public void DetectSimpleQuery()
+        {
+            Expression<Func<Entity_Complex, bool>> expression = e => e.ID > 3;
+            var visitor = new BatchDeleteVisitor();
+            visitor.Visit(expression);
+            Assert.IsTrue(visitor.IsSimpleQuery);
+        }
+    }
+}

--- a/src/test/Z.Test.EntityFramework.Plus.EF6/Z.Test.EntityFramework.Plus.EF6.csproj
+++ b/src/test/Z.Test.EntityFramework.Plus.EF6/Z.Test.EntityFramework.Plus.EF6.csproj
@@ -212,6 +212,8 @@
     <Compile Include="BatchDelete\InMemory\Twenty.cs" />
     <Compile Include="BatchDelete\PrimaryKey\Single.cs" />
     <Compile Include="BatchDelete\PrimaryKey\Many.cs" />
+    <Compile Include="BatchDelete\Visitor\DetectSimpleQuery.cs" />
+    <Compile Include="BatchDelete\Visitor\DetectComplexQuery.cs" />
     <Compile Include="BatchDelete\Visitor\OrderBy.cs" />
     <Compile Include="BatchDelete\Visitor\Skip.cs" />
     <Compile Include="BatchDelete\Visitor\Take.cs" />


### PR DESCRIPTION
Fixes #312 

The goal of the PR is to avoid additional joins if a `IQueryable<T>` is pretty simple, e.g. it references only a target query and doesn't use joins, unions etc.

It allows to simplify a query from the issue to something like
```UPDATE A 
SET A.[Name] = @zzz_BatchUpdate_0,
A.[Description] = @zzz_BatchUpdate_1,
A.[LastModificationDate] = @zzz_BatchUpdate_2,
A.[Group] = @zzz_BatchUpdate_3,
A.[Enabled] = @zzz_BatchUpdate_4,
A.[DisableDate] = @zzz_BatchUpdate_5
FROM ( SELECT 
    [Extent1].[Id] AS [Id], 
    [Extent1].[Name] AS [Name], 
    [Extent1].[Description] AS [Description], 
    [Extent1].[LastModificationDate] AS [LastModificationDate],
    [Extent1].[Group] AS [Group], 
    [Extent1].[Enabled] AS [Enabled], 
    [Extent1].[DisableDate] AS [DisableDate]
    FROM [dbo].[Configuration] AS [Extent1]
    WHERE [Extent1].[Id] = @p__linq__0
           ) AS A
```

The PR only works for SqlServer syntax.

Also batchDeletes look like

```
exec sp_executesql N'
DECLARE @rowAffected INT
DECLARE @totalRowAffected INT

SET @totalRowAffected = 0

WHILE @rowAffected IS NULL
    OR @rowAffected > 0
    BEGIN
        DELETE TOP (1000)
        FROM    A 
        FROM    ( SELECT 
    [Extent1].[Id] AS [Id]
    FROM [dbo].[TableToUpdate] AS [Extent1]
    WHERE ([Extent1].[Id] >= @p__linq__0) AND ([Extent1].[Id] <= @p__linq__1)
                           ) A
        SET @rowAffected = @@ROWCOUNT
        SET @totalRowAffected = @totalRowAffected + @rowAffected
    END

SELECT  @totalRowAffected
',N'@p__linq__0 int,@p__linq__1 int',@p__linq__0=34,@p__linq__1=34`
```