### PR TITLE
fix. NullReferenceException while performs an implicit conversion fro…

### DIFF
--- a/src/shared/Z.EF.Plus.QueryFuture.Shared/QueryFutureValue.cs
+++ b/src/shared/Z.EF.Plus.QueryFuture.Shared/QueryFutureValue.cs
@@ -146,6 +146,11 @@ namespace Z.EntityFramework.Plus
         /// <returns>The result of forcing this lazy value.</returns>
         public static implicit operator TResult(QueryFutureValue<TResult> futureValue)
         {
+            if (futureValue == null)
+            {
+                return default(TResult);
+            }
+
             return futureValue.Value;
         }
     }

--- a/src/test/Z.Test.EntityFramework.Plus.EF6/QueryFuture/FutureValue/ImplicitCastTest.cs
+++ b/src/test/Z.Test.EntityFramework.Plus.EF6/QueryFuture/FutureValue/ImplicitCastTest.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Z.EntityFramework.Plus;
+
+namespace Z.Test.EntityFramework.Plus
+{
+    public partial class QueryFuture_FutureValue
+    {
+        [TestMethod]
+        public void Try_Cast_Null_FutureValue_To_Certain_Type_Should_Return_Null()
+        {
+            QueryFutureValue<string> futureValue = null;
+            string tmp = futureValue;
+
+            Assert.IsNull(tmp);
+        }
+    }
+}

--- a/src/test/Z.Test.EntityFramework.Plus.EF6/Z.Test.EntityFramework.Plus.EF6.csproj
+++ b/src/test/Z.Test.EntityFramework.Plus.EF6/Z.Test.EntityFramework.Plus.EF6.csproj
@@ -327,6 +327,7 @@
     <Compile Include="QueryFilter\DbContext_Filter\WithParameter\SingleFilter_SingleParameter.cs" />
     <Compile Include="QueryFilter\DbContext_Filter\WithParameter\SingleFilter_ManyParameter.cs" />
     <Compile Include="QueryFilter\DbContext_Filter\WithParameter\SingleFilter_NoParameter.cs" />
+    <Compile Include="QueryFuture\FutureValue\ImplicitCastTest.cs" />
     <Compile Include="QueryIncludeOptimized\ByPath\Many_Many_Many_Many.cs" />
     <Compile Include="QueryIncludeOptimized\ByPath\Many_Many_Many_Single.cs" />
     <Compile Include="QueryIncludeOptimized\ByPath\Many_Many_Single_Many.cs" />


### PR DESCRIPTION
NullReferenceException while performs an implicit conversion from QueryFutureValue to TResult. #333

```
StackTrace:
Test method Z.Test.EntityFramework.Plus.QueryFuture_FutureValue.Try_Cast_Null_FutureValue_To_Certain_Type_Should_Return_Null threw exception: 
System.NullReferenceException: Object reference not set to an instance of an object.
    at Z.EntityFramework.Plus.QueryFutureValue`1.op_Implicit(QueryFutureValue`1 futureValue) in D:\repositories\EntityFramework-Plus\src\shared\Z.EF.Plus.QueryFuture.Shared\QueryFutureValue.cs:line 154
   at Z.Test.EntityFramework.Plus.QueryFuture_FutureValue.Try_Cast_Null_FutureValue_To_Certain_Type_Should_Return_Null() in D:\repositories\EntityFramework-Plus\src\test\Z.Test.EntityFramework.Plus.EF6\QueryFuture\FutureValue\ImplicitCastTest.cs:line 12
```