### PR TITLE
Pull Request adding FirstOrDefault implementation for QueryFutureEnumerable class. Makes is easier and convenient to get first item when quering async from EF

### DIFF
--- a/src/shared/Z.EF.Plus.QueryFuture.Shared/QueryFutureEnumerable.cs
+++ b/src/shared/Z.EF.Plus.QueryFuture.Shared/QueryFutureEnumerable.cs
@@ -121,6 +121,25 @@ namespace Z.EntityFramework.Plus
                 return list.ToArray();
             }
         }
+
+        public async Task<T> FirstOrDefaultAsync()
+        {
+            if (!HasValue)
+            {
+                await OwnerBatch.ExecuteQueriesAsync().ConfigureAwait(false);
+            }
+
+            if (_result == null)
+            {
+                return default(T);
+            }
+
+            using (var enumerator = _result.GetEnumerator())
+            {
+                enumerator.MoveNext();
+                return enumerator.Current;
+            }
+        }
 #endif
 
         /// <summary>Sets the result of the query deferred.</summary>


### PR DESCRIPTION
feat(QueryFutureEnumerable) : add FirstOrDefaultAsync implementation