### PR TITLE
Fix IncludeOptimized function issue with EF Inheritance (TPT)

### DIFF
--- a/src/shared/Z.EF.Plus.QueryIncludeOptimized.Shared/QueryIncludeOptimizedProvider.cs
+++ b/src/shared/Z.EF.Plus.QueryIncludeOptimized.Shared/QueryIncludeOptimizedProvider.cs
@@ -195,7 +195,7 @@ namespace Z.EntityFramework.Plus
                     // MODIFY query if necessary
 #if EF5 || EF6
                     var objectContext = CurrentQueryable.OriginalQueryable.GetObjectQuery().Context;
-                    var keyMembers = ((dynamic)objectContext).CreateObjectSet<T>().EntitySet.ElementType.KeyMembers;
+                    var keyMembers = objectContext.GetEntitySet<T>().ElementType.KeyMembers;
                     var keyNames = ((IEnumerable<EdmMember>)keyMembers).Select(x => x.Name).ToArray();
 #elif EFCORE
 


### PR DESCRIPTION
When using IncluedOptimized function with EF 6 inheritance strategy (TPT) it throws the following exception 

> There are no EntitySets defined for the specified entity type 'XYZ'. If 'XYZ' is a derived type, use the base type instead.Parameter name: TEntity'

because the function depends on "CreateObjectSet" method in  "ObjectContext" class to get the key members of the entity which is the source of the exception and it is known issue in EF.So I changed the way to get the key members using extension function in "Z.EntityFramework.Plus.InternalExtensions" class called "GetEntitySet" .
This fix also related to this issue [https://github.com/zzzprojects/EntityFramework-Plus/issues/119](url).
I know it might be this is not the best solution but this the best I can get to fix the issue regarding to my case  
