### PR TITLE
Npgsql+IncludeOptimized: fixes "System.NotSupportedException: CLR type System.Object isn't supported

### DIFF
--- a/src/shared/Z.EF.Plus._Core.Shared/EF/DbParameter/DbParameter.CopyFrom.cs
+++ b/src/shared/Z.EF.Plus._Core.Shared/EF/DbParameter/DbParameter.CopyFrom.cs
@@ -55,6 +55,11 @@ namespace Z.EntityFramework.Plus
                   var property = from.GetType().GetProperty("OracleDbType");
                   property.SetValue(@this, property.GetValue(from, null), new object[0]);
             }
+            else if (fullName.Contains("Npgsql") && from.GetType().GetProperty("NpgsqlDbType") != null)
+            {
+                var property = from.GetType().GetProperty("NpgsqlDbType");
+                property.SetValue(@this, property.GetValue(from, null), new object[0]);
+            }
 #endif
 
             @this.Value = from.Value ?? DBNull.Value;
@@ -88,6 +93,11 @@ namespace Z.EntityFramework.Plus
             if (fullName.Contains("Oracle") && from.GetType().GetProperty("OracleDbType") != null)
             {
                 var property = from.GetType().GetProperty("OracleDbType");
+                property.SetValue(@this, property.GetValue(from, null), new object[0]);
+            }
+            else if (fullName.Contains("Npgsql") && from.GetType().GetProperty("NpgsqlDbType") != null)
+            {
+                var property = from.GetType().GetProperty("NpgsqlDbType");
                 property.SetValue(@this, property.GetValue(from, null), new object[0]);
             }
 #endif


### PR DESCRIPTION
Fixes "System.NotSupportedException: CLR type System.Object isn't supported by Npgsql" type exceptions when using *IncludeOptimized* with Npgsql and a query that employs a `x => array.Contains(x.Id)` type expression.

This commit fixes the following use case which would previously throw the above System.NotSupportedException when using Npgsql (a .NET Postgres client SDK):
```
var ids = new Guid [] { Guid.Parse("838de2e2-d18d-49d1-8f03-7351a6e99a55d"), Guid.Parse("9380a5dc-ceb6-4fa4-a30b-a583d1ba00b") };
var entities = await _dbContext.MainRows
    .Where(x => ids.Contains(x.Id))
    .IncludeOptimized(x => x.ChildRows)
    .ToListAsync();
```