### PR TITLE
Change AsNoFilter extension method to take IQueryable<T> parameter

### DIFF
--- a/src/shared/Z.EF.Plus.QueryFilterInterceptor.Shared/Extensions/IDbSet.AsNoFilter.cs
+++ b/src/shared/Z.EF.Plus.QueryFilterInterceptor.Shared/Extensions/IDbSet.AsNoFilter.cs
@@ -5,7 +5,6 @@
 // More projects: http://www.zzzprojects.com/
 // Copyright © ZZZ Projects Inc. 2014 - 2016. All rights reserved.
 
-using System.Data.Entity;
 using System.Linq;
 
 namespace Z.EntityFramework.Plus
@@ -16,7 +15,7 @@ namespace Z.EntityFramework.Plus
         /// <typeparam name="T">The type of elements of the query.</typeparam>
         /// <param name="query">The filtered query from which the original query should be retrieved.</param>
         /// <returns>The orginal query before the context was filtered.</returns>
-        public static IQueryable<T> AsNoFilter<T>(this IDbSet<T> query) where T : class
+        public static IQueryable<T> AsNoFilter<T>(this IQueryable<T> query) where T : class
         {
             return QueryFilterManager.HookFilter(query, QueryFilterManager.DisableAllFilter);
         }


### PR DESCRIPTION
The AsNoFilter() extension method currently expects a query parameter of type IDbSet<T>, even though it is implemented in terms of a method that only expects an IQueryable<T>.

The proposed change makes the query parameter's type no more specific than what is actually needed; thus changing it to IQueryable<T>.