### PR TITLE
Fix/handle take in batch updates

### DIFF
--- a/src/shared/Z.EF.Plus.BatchUpdate.Shared/BatchUpdate.cs
+++ b/src/shared/Z.EF.Plus.BatchUpdate.Shared/BatchUpdate.cs
@@ -1455,10 +1455,10 @@ SELECT  @totalRowAffected
 
                     var valueSql = commandText.Substring(6, pos);
 #endif
-					if (valueSql.Trim().StartsWith("TOP") && valueSql.IndexOf(")") != -1)
-					{
-						valueSql = valueSql.Substring(valueSql.IndexOf(")") + 1);
-					}
+                    if (valueSql.Trim().StartsWith("TOP") && valueSql.IndexOf(")") != -1)
+                    {
+                        valueSql = valueSql.Substring(valueSql.IndexOf(")") + 1);
+                    }
 
                     valueSql = valueSql.Trim();
 

--- a/src/shared/Z.EF.Plus.BatchUpdate.Shared/BatchUpdate.cs
+++ b/src/shared/Z.EF.Plus.BatchUpdate.Shared/BatchUpdate.cs
@@ -1455,6 +1455,10 @@ SELECT  @totalRowAffected
 
                     var valueSql = commandText.Substring(6, pos);
 #endif
+					if (valueSql.Trim().StartsWith("TOP") && valueSql.IndexOf(")") != -1)
+					{
+						valueSql = valueSql.Substring(valueSql.IndexOf(")") + 1);
+					}
 
                     valueSql = valueSql.Trim();
 


### PR DESCRIPTION
Hello,

The goal of this PR is to sanitize ```TOP``` statements that appear when using Take() in the query. This is to avoid copying over the the ```'TOP'``` clause during the selection of the 'value part' of the ```commandSql```.

Note: this is already in place in the ```EF5``` and ```EF6``` code paths, I simply copied this over to ```EFCORE```.