### PR TITLE
Convert primitives to objects

### DIFF
--- a/src/shared/Z.EF.Plus.QueryFuture.Shared/QueryFutureValue.cs
+++ b/src/shared/Z.EF.Plus.QueryFuture.Shared/QueryFutureValue.cs
@@ -144,7 +144,8 @@ namespace Z.EntityFramework.Plus
                 }
                 else
                 {
-                    value = query.Provider.Execute<TResult>(query.Expression);
+                    var temp = Expression.Convert(query.Expression, typeof(object));
+                    value = query.Provider.Execute<object>(temp);
                 } 
 
                 if (value is TResult valueTResult)


### PR DESCRIPTION
We ran into this error debugging unit tests that failed after package update.
This is where I found the solution. https://stackoverflow.com/questions/2200209/expression-of-type-system-int32-cannot-be-used-for-return-type-system-object

Attached reproduction.
[QueryFuturePrimitive.zip](https://github.com/zzzprojects/EntityFramework-Plus/files/4866541/QueryFuturePrimitive.zip)
