### PR TITLE
Repairing concurrent QueryFilterManager use

### DIFF
--- a/src/shared/Z.EF.Plus.QueryFilter.Shared/QueryFilterManager.cs
+++ b/src/shared/Z.EF.Plus.QueryFilter.Shared/QueryFilterManager.cs
@@ -102,10 +102,7 @@ namespace Z.EntityFramework.Plus
             if (!CacheGenericFilterContext.TryGetValue(key, out filterContext))
             {
                 filterContext = new AliasQueryFilterContext(context, true);
-                if (!CacheGenericFilterContext.TryAdd(key, filterContext))
-                {
-                    CacheGenericFilterContext.TryGetValue(key, out filterContext);
-                }
+                filterContext = CacheGenericFilterContext.GetOrAdd(key, filterContext);
             }
 
             return filterContext;
@@ -178,10 +175,7 @@ namespace Z.EntityFramework.Plus
 #else
                 filter = new QueryFilter<T>(null, queryFilter) { IsDefaultEnabled = isEnabled };
 #endif
-                if (!GlobalFilters.TryAdd(key, filter))
-                {
-                    GlobalFilters.TryGetValue(key, out filter);
-                }
+                filter = GlobalFilters.GetOrAdd(key, filter);
             }
 
             return filter;

--- a/src/shared/Z.EF.Plus.QueryFilter.Shared/QueryFilterManager.cs
+++ b/src/shared/Z.EF.Plus.QueryFilter.Shared/QueryFilterManager.cs
@@ -6,6 +6,7 @@
 // Copyright © ZZZ Projects Inc. 2014 - 2016. All rights reserved.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -53,11 +54,11 @@ namespace Z.EntityFramework.Plus
         {
             EntityFrameworkManager.IsEntityFrameworkPlus = true;
 
-            CacheGenericFilterContext = new Dictionary<string, AliasQueryFilterContext>();
+            CacheGenericFilterContext = new ConcurrentDictionary<string, AliasQueryFilterContext>();
             CacheWeakFilterContext = new ConditionalWeakTable<DbContext, AliasQueryFilterContext>();
             CacheWeakFilterQueryable = new ConditionalWeakTable<IQueryable, AliasBaseQueryFilterQueryable>();
-            GlobalFilters = new Dictionary<object, AliasBaseQueryFilter>();
-            GlobalInitializeFilterActions = new List<Tuple<AliasBaseQueryFilter, Action<AliasBaseQueryFilter>>>();
+            GlobalFilters = new ConcurrentDictionary<object, AliasBaseQueryFilter>();
+            GlobalInitializeFilterActions = new ConcurrentBag<Tuple<AliasBaseQueryFilter, Action<AliasBaseQueryFilter>>>();
 
 #if NETSTANDARD2_0 && !EFCLASSIC
     ForceCast = true;
@@ -72,15 +73,15 @@ namespace Z.EntityFramework.Plus
 
         /// <summary>Gets the global filters.</summary>
         /// <value>The global filters.</value>
-        public static Dictionary<object, AliasBaseQueryFilter> GlobalFilters { get; }
+        public static ConcurrentDictionary<object, AliasBaseQueryFilter> GlobalFilters { get; }
 
         /// <summary>Gets or sets the global initialize filter actions.</summary>
         /// <value>The global initialize filter actions.</value>
-        public static List<Tuple<AliasBaseQueryFilter, Action<AliasBaseQueryFilter>>> GlobalInitializeFilterActions { get; set; }
+        public static ConcurrentBag<Tuple<AliasBaseQueryFilter, Action<AliasBaseQueryFilter>>> GlobalInitializeFilterActions { get; set; }
 
         /// <summary>Gets or sets the dictionary containing generic filter context information for a DbContext.FullName.</summary>
         /// <value>The dictionary containing generic filter context information for a DbContext.FullName.</value>
-        public static Dictionary<string, AliasQueryFilterContext> CacheGenericFilterContext { get; set; }
+        public static ConcurrentDictionary<string, AliasQueryFilterContext> CacheGenericFilterContext { get; set; }
 
         /// <summary>Gets or sets the weak table containing filter context for a specified context.</summary>
         /// <value>The weak table containing filter context for a specified context.</value>
@@ -100,13 +101,10 @@ namespace Z.EntityFramework.Plus
 
             if (!CacheGenericFilterContext.TryGetValue(key, out filterContext))
             {
-                lock (GenericFilterContextLock)
+                filterContext = new AliasQueryFilterContext(context, true);
+                if (!CacheGenericFilterContext.TryAdd(key, filterContext))
                 {
-                    if (!CacheGenericFilterContext.TryGetValue(key, out filterContext))
-                    {
-                        filterContext = new AliasQueryFilterContext(context, true);
-                        CacheGenericFilterContext.Add(key, filterContext);
-                    }
+                    CacheGenericFilterContext.TryGetValue(key, out filterContext);
                 }
             }
 
@@ -180,7 +178,10 @@ namespace Z.EntityFramework.Plus
 #else
                 filter = new QueryFilter<T>(null, queryFilter) { IsDefaultEnabled = isEnabled };
 #endif
-                GlobalFilters.Add(key, filter);
+                if (!GlobalFilters.TryAdd(key, filter))
+                {
+                    GlobalFilters.TryGetValue(key, out filter);
+                }
             }
 
             return filter;


### PR DESCRIPTION
Noticed some issues while running concurrent tests against a context- the original dictionary implementation wasn't doing well with concurrent reads.  This flips to concurrent data types for less issues/explicit locks.