### PR TITLE
Fix a bug with formatting nullable types

### DIFF
--- a/src/shared/Z.EF.Plus.Audit.Shared/AuditConfiguration/FormatValue.cs
+++ b/src/shared/Z.EF.Plus.Audit.Shared/AuditConfiguration/FormatValue.cs
@@ -57,7 +57,10 @@ namespace Z.EntityFramework.Plus
                         }
                     }
 
-                    ValueFormatterDictionary.TryAdd(key, formatter);
+                    if (formatter != null)
+                    {
+                        ValueFormatterDictionary.TryAdd(key, formatter);
+                    }
                 }
 
                 if (formatter != null)


### PR DESCRIPTION
The `FormatValue()` method can be called multiple times on the same entity (at least once for formatting `OldValue` and once for formatting `NewValue`). If it fails to find an appropriate formatter the first time (which can happen if the value is null, for example), it adds the (null) formatter to the dictionary. Then, when it's called the next time, `TryGetValue` finds a formatter in the dictionary (but it's null) causing it to revert to the default formatting even when it shouldn't.

Fixed by ensuring the formatter isn't null before adding it to the dictionary.

The problem described above can easily be reproduced by attempting to format any nullable type a first time when the value is null and a second time when it isn't. For example:

```
AuditManager.DefaultConfiguration.FormatType<DateTime?>(d => d?.ToString("yyyy-MM-dd"));
```