### PR TITLE
Add extension points before and after a Future query is run.

### DIFF
--- a/src/shared/Z.EF.Plus.QueryFuture.Shared/QueryFutureBatch.cs
+++ b/src/shared/Z.EF.Plus.QueryFuture.Shared/QueryFutureBatch.cs
@@ -183,6 +183,7 @@ namespace Z.EntityFramework.Plus
 
                     using (command)
                     {
+                        QueryFutureManager.OnBatchExecuting?.Invoke(command);
 #if EF5
                     using (var reader = command.ExecuteReader())
                     {
@@ -213,6 +214,7 @@ namespace Z.EntityFramework.Plus
                             }
                         }
 #endif
+                        QueryFutureManager.OnBatchExecuted?.Invoke(command);
                     }
                 }
                 finally

--- a/src/shared/Z.EF.Plus.QueryFuture.Shared/QueryFutureManager.cs
+++ b/src/shared/Z.EF.Plus.QueryFuture.Shared/QueryFutureManager.cs
@@ -7,6 +7,8 @@
 
 using System.Runtime.CompilerServices;
 using Z.EntityFramework.Extensions;
+using System;
+using System.Data.Common;
 
 #if NET45 || EFCORE
 
@@ -52,6 +54,12 @@ namespace Z.EntityFramework.Plus
         /// <summary>Gets or sets a value indicating whether we allow query batch.</summary>
         /// <value>True if allow query batch, false if not.</value>
         public static bool AllowQueryBatch { get; set; } = true;
+
+        /// <summary>Gets or sets a delegate to be invoked directly before executing the batch DbCommand.</summary>
+        public static Action<DbCommand> OnBatchExecuting { get; set; } = cmd => { };  
+
+        /// <summary>Gets or sets a delegate to be invoked directly after executing the batch DbCommand.</summary>
+        public static Action<DbCommand> OnBatchExecuted { get; set; } = cmd => { };
 
         /// <summary>Gets or sets the weak table used to cache future batch associated to a context.</summary>
         /// <value>The weak table used to cache future batch associated to a context.</value>

--- a/src/shared/Z.EF.Plus.QueryFuture.Shared/QueryFutureManager.cs
+++ b/src/shared/Z.EF.Plus.QueryFuture.Shared/QueryFutureManager.cs
@@ -56,10 +56,18 @@ namespace Z.EntityFramework.Plus
         public static bool AllowQueryBatch { get; set; } = true;
 
         /// <summary>Gets or sets a delegate to be invoked directly before executing the batch DbCommand.</summary>
-        public static Action<DbCommand> OnBatchExecuting { get; set; } = cmd => { };  
+        /// <remarks>
+        /// This delegate is only invoked when queries are actually executed as a batch containing multiple queries.  
+        /// i.e. When AllowQueryBatch=false or only a single query is pending, this delegate is not invoked.
+        /// </remarks>
+        public static Action<DbCommand> OnBatchExecuting { get; set; } = null;
 
         /// <summary>Gets or sets a delegate to be invoked directly after executing the batch DbCommand.</summary>
-        public static Action<DbCommand> OnBatchExecuted { get; set; } = cmd => { };
+        /// <remarks>
+        /// This delegate is only invoked when queries are actually executed as a batch containing multiple queries.  
+        /// i.e. When AllowQueryBatch=false or only a single query is pending, this delegate is not invoked.
+        /// </remarks>
+        public static Action<DbCommand> OnBatchExecuted { get; set; } = null;
 
         /// <summary>Gets or sets the weak table used to cache future batch associated to a context.</summary>
         /// <value>The weak table used to cache future batch associated to a context.</value>


### PR DESCRIPTION
Add optional extension points to QueryFutureManager before/after a QueryFutureBatch is run.  This would enable observing and/or modifying the DbCommand containing the batch of queries.