### PR TITLE
Enable tag fast path on EF Core

### DIFF
--- a/src/Z.Test.EntityFramework.Plus.EFCore.Shared/ExceptionMessage.cs
+++ b/src/Z.Test.EntityFramework.Plus.EFCore.Shared/ExceptionMessage.cs
@@ -26,6 +26,7 @@ namespace Z.EntityFramework.Plus
 #if FULL || QUERY_CACHE
         public static string QueryCache_FirstTagNullOrEmpty = "Oops! The option 'UseFirstTagAsCacheKey' is enabled but we found no tag, an empty tag string, or a null tag string instead. Make sure a tag is provided, and it's not null or empty. For more information, contact us: info@zzzprojects.com";
         public static string QueryCache_UseTagsNullOrEmpty = "Oops! The option 'UseTagsAsCacheKey' is enabled but we found no tag, an empty tag string, or a null tag string instead. Make sure a tag is provided, and it's not null or empty. For more information, contact us: info@zzzprojects.com";    
+        public static string QueryCache_IsCommandInfoOptionalForCacheKey_Invalid = "Oops! When the option 'IsCommandInfoOptionalForCacheKey' is enabled, one of the following options must also be enabled: 'UseFirstTagAsCacheKey' or 'UseTagsAsCacheKey'. For more information, contact us: info@zzzprojects.com";
 #endif
 #if FULL || QUERY_INCLUDEFILTER
         public static string QueryIncludeFilter_ArgumentExpression = "Oops! immediate method with expression argument are not supported in EF+ Query IncludeFilter. For more information, contact us: info@zzzprojects.com";

--- a/src/Z.Test.EntityFramework.Plus.EFCore.Shared/QueryCache/IsCommandInfoOptionalForCacheKey/Disabled_KeyUnchanged.cs
+++ b/src/Z.Test.EntityFramework.Plus.EFCore.Shared/QueryCache/IsCommandInfoOptionalForCacheKey/Disabled_KeyUnchanged.cs
@@ -1,0 +1,69 @@
+﻿// Description: Entity Framework Bulk Operations & Utilities (EF Bulk SaveChanges, Insert, Update, Delete, Merge | LINQ Query Cache, Deferred, Filter, IncludeFilter, IncludeOptimize | Audit)
+// Website & Documentation: https://github.com/zzzprojects/Entity-Framework-Plus
+// Forum & Issues: https://github.com/zzzprojects/EntityFramework-Plus/issues
+// License: https://github.com/zzzprojects/EntityFramework-Plus/blob/master/LICENSE
+// More projects: http://www.zzzprojects.com/
+// Copyright © ZZZ Projects Inc. 2014 - 2016. All rights reserved.
+
+using System;
+using System.Linq;
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Z.EntityFramework.Plus;
+
+namespace Z.Test.EntityFramework.Plus
+{
+    public partial class QueryCache_IsCommandInfoOptionalForCacheKey
+    {
+        [TestMethod]
+        public void Disabled_KeyUnchanged()
+        {
+            Action action = () =>
+            {
+                TestContext.DeleteAll(x => x.Entity_Basics);
+                TestContext.Insert(x => x.Entity_Basics, 3);
+
+                using (var ctx = new TestContext())
+                {
+                    var firstTag = "zzzprojects";
+                    var columnInt = 987654;
+
+                    StringBuilder cacheKey = new StringBuilder();
+                    cacheKey.AppendLine(QueryCacheManager.CachePrefix);
+                    cacheKey.AppendLine(QueryCacheManager.GetConnectionStringForCacheKey(ctx.Entity_Basics));
+                    cacheKey.AppendLine(firstTag);
+
+                    var query = ctx.Entity_Basics.Where(x => x.ColumnInt > columnInt);
+
+                    var cacheKey1 = QueryCacheManager.GetCacheKey(query, new[] {firstTag});
+
+                    QueryCacheManager.IsCommandInfoOptionalForCacheKey = true;
+                    QueryCacheManager.UseFirstTagAsCacheKey = true;
+
+                    try
+                    {
+                        var cacheKey2 = QueryCacheManager.GetCacheKey(query, new[] {firstTag});
+
+                        Assert.AreNotEqual(cacheKey1, cacheKey2);
+                    }
+                    finally
+                    {
+                        QueryCacheManager.UseFirstTagAsCacheKey = false;
+                        QueryCacheManager.IsCommandInfoOptionalForCacheKey = false;
+                    }
+
+                    var cacheKey3 = QueryCacheManager.GetCacheKey(query, new[] {firstTag});
+
+                    // The default cache key still contains the connection, the command and the parameter value
+                    Assert.IsTrue(cacheKey1.StartsWith(cacheKey.ToString()));
+                    Assert.IsTrue(cacheKey1.Contains(columnInt.ToString()));
+
+                    // The default cache key is left untouched by the fast path
+                    Assert.AreEqual(cacheKey1, cacheKey3);
+                }
+            };
+
+            MyIni.RunWithFailLogical(MyIni.GetSetupCasTest(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType.FullName + "." + System.Reflection.MethodBase.GetCurrentMethod().Name), action);
+        }
+    }
+}

--- a/src/Z.Test.EntityFramework.Plus.EFCore.Shared/QueryCache/IsCommandInfoOptionalForCacheKey/DoesNotCompileQuery.cs
+++ b/src/Z.Test.EntityFramework.Plus.EFCore.Shared/QueryCache/IsCommandInfoOptionalForCacheKey/DoesNotCompileQuery.cs
@@ -1,0 +1,77 @@
+﻿// Description: Entity Framework Bulk Operations & Utilities (EF Bulk SaveChanges, Insert, Update, Delete, Merge | LINQ Query Cache, Deferred, Filter, IncludeFilter, IncludeOptimize | Audit)
+// Website & Documentation: https://github.com/zzzprojects/Entity-Framework-Plus
+// Forum & Issues: https://github.com/zzzprojects/EntityFramework-Plus/issues
+// License: https://github.com/zzzprojects/EntityFramework-Plus/blob/master/LICENSE
+// More projects: http://www.zzzprojects.com/
+// Copyright © ZZZ Projects Inc. 2014 - 2016. All rights reserved.
+
+using System;
+using System.Linq;
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Z.EntityFramework.Plus;
+
+namespace Z.Test.EntityFramework.Plus
+{
+    public partial class QueryCache_IsCommandInfoOptionalForCacheKey
+    {
+        [TestMethod]
+        public void DoesNotCompileQuery()
+        {
+            Action action = () =>
+            {
+                TestContext.DeleteAll(x => x.Entity_Basics);
+                TestContext.Insert(x => x.Entity_Basics, 3);
+
+                using (var ctx = new TestContext())
+                {
+                    var firstTag = "zzzprojects";
+
+                    StringBuilder cacheKey = new StringBuilder();
+                    cacheKey.AppendLine(QueryCacheManager.CachePrefix);
+                    cacheKey.AppendLine(firstTag);
+
+                    // The query cannot be translated, so creating the cache key fails whenever the query is compiled
+                    var query = ctx.Entity_Basics.Where(x => CannotBeTranslated(x.ColumnInt));
+
+                    Exception compileException = null;
+
+                    try
+                    {
+                        var cacheKey1 = QueryCacheManager.GetCacheKey(query, new[] {firstTag});
+                    }
+                    catch (Exception ex)
+                    {
+                        compileException = ex;
+                    }
+
+                    // The query is compiled by default
+                    Assert.IsNotNull(compileException);
+
+                    QueryCacheManager.IsCommandInfoOptionalForCacheKey = true;
+                    QueryCacheManager.UseFirstTagAsCacheKey = true;
+
+                    try
+                    {
+                        // The query is not compiled anymore
+                        var cacheKey2 = QueryCacheManager.GetCacheKey(query, new[] {firstTag});
+
+                        Assert.AreEqual(cacheKey.ToString(), cacheKey2);
+                    }
+                    finally
+                    {
+                        QueryCacheManager.UseFirstTagAsCacheKey = false;
+                        QueryCacheManager.IsCommandInfoOptionalForCacheKey = false;
+                    }
+                }
+            };
+
+            MyIni.RunWithFailLogical(MyIni.GetSetupCasTest(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType.FullName + "." + System.Reflection.MethodBase.GetCurrentMethod().Name), action);
+        }
+
+        private static bool CannotBeTranslated(int value)
+        {
+            return value > 0;
+        }
+    }
+}

--- a/src/Z.Test.EntityFramework.Plus.EFCore.Shared/QueryCache/IsCommandInfoOptionalForCacheKey/WithFirstTag.cs
+++ b/src/Z.Test.EntityFramework.Plus.EFCore.Shared/QueryCache/IsCommandInfoOptionalForCacheKey/WithFirstTag.cs
@@ -1,0 +1,65 @@
+﻿// Description: Entity Framework Bulk Operations & Utilities (EF Bulk SaveChanges, Insert, Update, Delete, Merge | LINQ Query Cache, Deferred, Filter, IncludeFilter, IncludeOptimize | Audit)
+// Website & Documentation: https://github.com/zzzprojects/Entity-Framework-Plus
+// Forum & Issues: https://github.com/zzzprojects/EntityFramework-Plus/issues
+// License: https://github.com/zzzprojects/EntityFramework-Plus/blob/master/LICENSE
+// More projects: http://www.zzzprojects.com/
+// Copyright © ZZZ Projects Inc. 2014 - 2016. All rights reserved.
+
+using System;
+using System.Linq;
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Z.EntityFramework.Plus;
+
+namespace Z.Test.EntityFramework.Plus
+{
+    public partial class QueryCache_IsCommandInfoOptionalForCacheKey
+    {
+        [TestMethod]
+        public void WithFirstTag()
+        {
+            Action action = () =>
+            {
+                TestContext.DeleteAll(x => x.Entity_Basics);
+                TestContext.Insert(x => x.Entity_Basics, 3);
+
+                using (var ctx = new TestContext())
+                {
+                    var firstTag = "zzzprojects";
+
+                    StringBuilder cacheKey = new StringBuilder();
+                    cacheKey.AppendLine(QueryCacheManager.CachePrefix);
+                    cacheKey.AppendLine(firstTag);
+
+                    var query = ctx.Entity_Basics.Where(x => x.ColumnInt > 0);
+
+                    var cacheKey1 = QueryCacheManager.GetCacheKey(query, new string[0]);
+
+                    QueryCacheManager.IsCommandInfoOptionalForCacheKey = true;
+                    QueryCacheManager.UseFirstTagAsCacheKey = true;
+
+                    try
+                    {
+                        var cacheKey2 = QueryCacheManager.GetCacheKey(query, new[] {firstTag, "tag2"});
+
+                        // Cache key are different
+                        Assert.AreNotEqual(cacheKey1, cacheKey2);
+
+                        // Cache key2 is equal to hardcoded cacheKey, the connection and the command are omitted
+                        Assert.AreEqual(cacheKey.ToString(), cacheKey2);
+
+                        // The query is still cached and returns the same items
+                        Assert.AreEqual(2, query.FromCache(firstTag, "tag2").Count());
+                    }
+                    finally
+                    {
+                        QueryCacheManager.UseFirstTagAsCacheKey = false;
+                        QueryCacheManager.IsCommandInfoOptionalForCacheKey = false;
+                    }
+                }
+            };
+
+            MyIni.RunWithFailLogical(MyIni.GetSetupCasTest(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType.FullName + "." + System.Reflection.MethodBase.GetCurrentMethod().Name), action);
+        }
+    }
+}

--- a/src/Z.Test.EntityFramework.Plus.EFCore.Shared/QueryCache/IsCommandInfoOptionalForCacheKey/WithTags.cs
+++ b/src/Z.Test.EntityFramework.Plus.EFCore.Shared/QueryCache/IsCommandInfoOptionalForCacheKey/WithTags.cs
@@ -1,0 +1,65 @@
+﻿// Description: Entity Framework Bulk Operations & Utilities (EF Bulk SaveChanges, Insert, Update, Delete, Merge | LINQ Query Cache, Deferred, Filter, IncludeFilter, IncludeOptimize | Audit)
+// Website & Documentation: https://github.com/zzzprojects/Entity-Framework-Plus
+// Forum & Issues: https://github.com/zzzprojects/EntityFramework-Plus/issues
+// License: https://github.com/zzzprojects/EntityFramework-Plus/blob/master/LICENSE
+// More projects: http://www.zzzprojects.com/
+// Copyright © ZZZ Projects Inc. 2014 - 2016. All rights reserved.
+
+using System;
+using System.Linq;
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Z.EntityFramework.Plus;
+
+namespace Z.Test.EntityFramework.Plus
+{
+    public partial class QueryCache_IsCommandInfoOptionalForCacheKey
+    {
+        [TestMethod]
+        public void WithTags()
+        {
+            Action action = () =>
+            {
+                TestContext.DeleteAll(x => x.Entity_Basics);
+                TestContext.Insert(x => x.Entity_Basics, 3);
+
+                using (var ctx = new TestContext())
+                {
+                    var tags = new[] {"zzzprojects", "tag2", "tag3"};
+
+                    StringBuilder cacheKey = new StringBuilder();
+                    cacheKey.AppendLine(QueryCacheManager.CachePrefix);
+                    cacheKey.AppendLine(string.Join(";", tags));
+
+                    var query = ctx.Entity_Basics.Where(x => x.ColumnInt > 0);
+
+                    var cacheKey1 = QueryCacheManager.GetCacheKey(query, new string[0]);
+
+                    QueryCacheManager.IsCommandInfoOptionalForCacheKey = true;
+                    QueryCacheManager.UseTagsAsCacheKey = true;
+
+                    try
+                    {
+                        var cacheKey2 = QueryCacheManager.GetCacheKey(query, tags);
+
+                        // Cache key are different
+                        Assert.AreNotEqual(cacheKey1, cacheKey2);
+
+                        // Cache key2 is equal to hardcoded cacheKey, the connection and the command are omitted
+                        Assert.AreEqual(cacheKey.ToString(), cacheKey2);
+
+                        // The query is still cached and returns the same items
+                        Assert.AreEqual(2, query.FromCache(tags).Count());
+                    }
+                    finally
+                    {
+                        QueryCacheManager.UseTagsAsCacheKey = false;
+                        QueryCacheManager.IsCommandInfoOptionalForCacheKey = false;
+                    }
+                }
+            };
+
+            MyIni.RunWithFailLogical(MyIni.GetSetupCasTest(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType.FullName + "." + System.Reflection.MethodBase.GetCurrentMethod().Name), action);
+        }
+    }
+}

--- a/src/Z.Test.EntityFramework.Plus.EFCore.Shared/QueryCache/IsCommandInfoOptionalForCacheKey/WithoutTagMode_Throws.cs
+++ b/src/Z.Test.EntityFramework.Plus.EFCore.Shared/QueryCache/IsCommandInfoOptionalForCacheKey/WithoutTagMode_Throws.cs
@@ -1,0 +1,55 @@
+﻿// Description: Entity Framework Bulk Operations & Utilities (EF Bulk SaveChanges, Insert, Update, Delete, Merge | LINQ Query Cache, Deferred, Filter, IncludeFilter, IncludeOptimize | Audit)
+// Website & Documentation: https://github.com/zzzprojects/Entity-Framework-Plus
+// Forum & Issues: https://github.com/zzzprojects/EntityFramework-Plus/issues
+// License: https://github.com/zzzprojects/EntityFramework-Plus/blob/master/LICENSE
+// More projects: http://www.zzzprojects.com/
+// Copyright © ZZZ Projects Inc. 2014 - 2016. All rights reserved.
+
+using System;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Z.EntityFramework.Plus;
+
+namespace Z.Test.EntityFramework.Plus
+{
+    public partial class QueryCache_IsCommandInfoOptionalForCacheKey
+    {
+        [TestMethod]
+        public void WithoutTagMode_Throws()
+        {
+            Action action = () =>
+            {
+                TestContext.DeleteAll(x => x.Entity_Basics);
+                TestContext.Insert(x => x.Entity_Basics, 3);
+
+                using (var ctx = new TestContext())
+                {
+                    var query = ctx.Entity_Basics.Where(x => x.ColumnInt > 0);
+
+                    QueryCacheManager.IsCommandInfoOptionalForCacheKey = true;
+
+                    try
+                    {
+                        var cacheKey = QueryCacheManager.GetCacheKey(query, new[] {"zzzprojects"});
+
+                        Assert.Fail("The cache key should not have been created");
+                    }
+                    catch (AssertFailedException)
+                    {
+                        throw;
+                    }
+                    catch (Exception ex)
+                    {
+                        Assert.AreEqual(ExceptionMessage.QueryCache_IsCommandInfoOptionalForCacheKey_Invalid, ex.Message);
+                    }
+                    finally
+                    {
+                        QueryCacheManager.IsCommandInfoOptionalForCacheKey = false;
+                    }
+                }
+            };
+
+            MyIni.RunWithFailLogical(MyIni.GetSetupCasTest(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType.FullName + "." + System.Reflection.MethodBase.GetCurrentMethod().Name), action);
+        }
+    }
+}

--- a/src/Z.Test.EntityFramework.Plus.EFCore.Shared/QueryCache/QueryCache_IsCommandInfoOptionalForCacheKey.cs
+++ b/src/Z.Test.EntityFramework.Plus.EFCore.Shared/QueryCache/QueryCache_IsCommandInfoOptionalForCacheKey.cs
@@ -1,0 +1,16 @@
+﻿// Description: Entity Framework Bulk Operations & Utilities (EF Bulk SaveChanges, Insert, Update, Delete, Merge | LINQ Query Cache, Deferred, Filter, IncludeFilter, IncludeOptimize | Audit)
+// Website & Documentation: https://github.com/zzzprojects/Entity-Framework-Plus
+// Forum & Issues: https://github.com/zzzprojects/EntityFramework-Plus/issues
+// License: https://github.com/zzzprojects/EntityFramework-Plus/blob/master/LICENSE
+// More projects: http://www.zzzprojects.com/
+// Copyright © ZZZ Projects Inc. 2014 - 2016. All rights reserved.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Z.Test.EntityFramework.Plus
+{
+    [TestClass]
+    public partial class QueryCache_IsCommandInfoOptionalForCacheKey
+    {
+    }
+}

--- a/src/Z.Test.EntityFramework.Plus.EFCore.Shared/Z.Test.EntityFramework.Plus.EFCore.Shared.projitems
+++ b/src/Z.Test.EntityFramework.Plus.EFCore.Shared/Z.Test.EntityFramework.Plus.EFCore.Shared.projitems
@@ -280,11 +280,17 @@
     <Compile Include="$(MSBuildThisFileDirectory)QueryCache\FromCache\QueryDeferred_WithDefault.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)QueryCache\FromCache\QueryDeferred_WithExpiration.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)QueryCache\FromCache\QueryDeferred_WithNull.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)QueryCache\IsCommandInfoOptionalForCacheKey\Disabled_KeyUnchanged.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)QueryCache\IsCommandInfoOptionalForCacheKey\DoesNotCompileQuery.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)QueryCache\IsCommandInfoOptionalForCacheKey\WithFirstTag.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)QueryCache\IsCommandInfoOptionalForCacheKey\WithTags.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)QueryCache\IsCommandInfoOptionalForCacheKey\WithoutTagMode_Throws.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)QueryCache\QueryCache_CacheKey.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)QueryCache\QueryCache_CacheKeyFactory.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)QueryCache\QueryCache_ExpireAll.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)QueryCache\QueryCache_FromCache.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)QueryCache\QueryCache_FromCacheAsync.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)QueryCache\QueryCache_IsCommandInfoOptionalForCacheKey.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)QueryCache\QueryCache_IsEnabledFalse.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)QueryCache\QueryCache_Tag.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)QueryCache\QueryCache_UseFirstTagAsCacheKey.cs" />

--- a/src/shared/Z.EF.Plus.QueryCache.Shared/QueryCacheManager.cs
+++ b/src/shared/Z.EF.Plus.QueryCache.Shared/QueryCacheManager.cs
@@ -251,6 +251,11 @@ namespace Z.EntityFramework.Plus
         /// <value>
         /// True if this object is command information optional for cache key, false if not.
         /// </value>
+        /// <remarks>
+        /// The query is not compiled when this option is enabled, so the connection and the command are
+        /// omitted from the cache key. The option 'UseFirstTagAsCacheKey' or 'UseTagsAsCacheKey' must also
+        /// be enabled since the tags become the only information used to create the cache key.
+        /// </remarks>
         public static bool IsCommandInfoOptionalForCacheKey { get; set; }
 
 
@@ -508,13 +513,19 @@ namespace Z.EntityFramework.Plus
                 sb.AppendLine(GetConnectionStringForCacheKey(query));
             }
 #elif EFCORE
+            if (IsCommandInfoOptionalForCacheKey && !UseFirstTagAsCacheKey && !UseTagsAsCacheKey)
+            {
+                throw new Exception(ExceptionMessage.QueryCache_IsCommandInfoOptionalForCacheKey_Invalid);
+            }
+
             RelationalQueryContext queryContext = null;
 
-            var command = query.CreateCommand(out queryContext);
+            // Creating the command compiles the query, skip it when only tags are used to create the cache key
+            var command = IsCommandInfoOptionalForCacheKey ? null : query.CreateCommand(out queryContext);
 
             sb.AppendLine(CachePrefix);
 
-            if (IncludeConnectionInCacheKey)
+            if (IncludeConnectionInCacheKey && queryContext != null)
             {
                 sb.AppendLine(GetConnectionStringForCacheKey(queryContext));
             }


### PR DESCRIPTION
EF6 has a "fast path" for `IsCommandInfoOptionalForCacheKey`, but as far as I can tell EF Core doesn't use it. This wires up the property for the EF Core path too.